### PR TITLE
[Feat] Backoffice Image/Audio File GCP Storage 추가 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,8 @@ payments-backend-app/__pycache__/
 subscription-backend-app/__pycache__/
 # audio-streaming-backend-app/**/__pycache__/*
 audio-streaming-backend-app/__pycache__/
+# audio-storage-backend-app/**/__pycache__/*
+audio-storage-backend-app/__pycache__/
+# GCP Service Key
+*/graduation-work-*.json
 .DS_Store

--- a/backoffice-app/.gitignore
+++ b/backoffice-app/.gitignore
@@ -1,2 +1,0 @@
-# GCP Service Key
-graduation-work-*.json

--- a/backoffice-app/.gitignore
+++ b/backoffice-app/.gitignore
@@ -1,0 +1,2 @@
+# GCP Service Key
+graduation-work-*.json

--- a/backoffice-app/main.py
+++ b/backoffice-app/main.py
@@ -1,12 +1,35 @@
 import streamlit as st
 from PIL import Image
 from pymongo import MongoClient
+import os
+from google.cloud import storage
+
+
+def upload_file(bucket, file, file_name):
+    file.seek(0)
+    blob = bucket.blob(file_name)
+    blob.upload_from_file(file)
+    print(blob.public_url)
+    return blob.public_url
+    
+    
 
 if __name__ == "__main__":
+    bucket_name = '2024-graduation-music'
+    # Bucket Env, Connect
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"]="./graduation-work-434713-2fc06a1d16e0.json"
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+
+    # MongoDB Client 127.0.0.1 (LocalHost : 27071) 연결
+    # 이 과정에서는 DB가 생성되지는 않고 객체만 반환
     client = MongoClient(directConnection=True, host="127.0.0.1", port=27017)
+    # DB 중 test_database 사용
     db = client.test_database
+    # music collection 사용
     music_collection = db.music
 
+    ## UI
     st.title("SKKU music backoffice")
     st.subheader("음원 등록하기")
 
@@ -22,9 +45,17 @@ if __name__ == "__main__":
 
     audio = st.file_uploader("Upload Audio", accept_multiple_files=False)
 
+    # BackOffice -> GCP Bucket -> Url -> MongoDB
+    # audioUrl: 'https://storage.googleapis.com/<bucket_name>/<file_name>'
     if st.button("Save to Server"):
-        new_song = {"title": music_title, "artist": artist, "lyrics": lyrics, "like": False, "isDownloaded": False}
+        thumbnail_img_url = ""
+        audio_url = ""
+        if thumbnail_img is not None:
+            thumbnail_img_url = upload_file(bucket, thumbnail_img, f"thumbnail/{thumbnail_img.name}")
+        if audio is not None:
+            audio_url = upload_file(bucket, audio, f"music/{audio.name}")
 
+        new_song = {"title": music_title, "artist": artist, "lyrics": lyrics, "like": False, "isDownloaded": False, "imgUrl" : thumbnail_img_url, "audioUrl" : audio_url}
         iid = music_collection.insert_one(new_song).inserted_id
         print(iid)
 

--- a/backoffice-app/main.py
+++ b/backoffice-app/main.py
@@ -54,8 +54,11 @@ if __name__ == "__main__":
             thumbnail_img_url = upload_file(bucket, thumbnail_img, f"thumbnail/{thumbnail_img.name}")
         if audio is not None:
             audio_url = upload_file(bucket, audio, f"music/{audio.name}")
+        
+        img_name = thumbnail_img_url.split("thumbnail/")[-1]
+        audio_name = audio_url.split("music/")[-1]
 
-        new_song = {"title": music_title, "artist": artist, "lyrics": lyrics, "like": False, "isDownloaded": False, "imgUrl" : thumbnail_img_url, "audioUrl" : audio_url}
+        new_song = {"title": music_title, "artist": artist, "lyrics": lyrics, "like": False, "isDownloaded": False, "imgUrl" : img_name, "audioUrl" : audio_name}
         iid = music_collection.insert_one(new_song).inserted_id
         print(iid)
 

--- a/backoffice-app/main.py
+++ b/backoffice-app/main.py
@@ -11,8 +11,6 @@ def upload_file(bucket, file, file_name):
     blob.upload_from_file(file)
     print(blob.public_url)
     return blob.public_url
-    
-    
 
 if __name__ == "__main__":
     bucket_name = '2024-graduation-music'
@@ -45,20 +43,17 @@ if __name__ == "__main__":
 
     audio = st.file_uploader("Upload Audio", accept_multiple_files=False)
 
-    # BackOffice -> GCP Bucket -> Url -> MongoDB
+    # BackOffice -> GCP Bucket -> Uri -> MongoDB
     # audioUrl: 'https://storage.googleapis.com/<bucket_name>/<file_name>'
     if st.button("Save to Server"):
-        thumbnail_img_url = ""
-        audio_url = ""
+        img_uri = ""
+        audio_uri = ""
         if thumbnail_img is not None:
-            thumbnail_img_url = upload_file(bucket, thumbnail_img, f"thumbnail/{thumbnail_img.name}")
+            img_uri = upload_file(bucket, thumbnail_img, f"thumbnail/{thumbnail_img.name}")
         if audio is not None:
-            audio_url = upload_file(bucket, audio, f"music/{audio.name}")
+            audio_uri = upload_file(bucket, audio, f"music/{audio.name}")
         
-        img_name = thumbnail_img_url.split("thumbnail/")[-1]
-        audio_name = audio_url.split("music/")[-1]
-
-        new_song = {"title": music_title, "artist": artist, "lyrics": lyrics, "like": False, "isDownloaded": False, "imgUrl" : img_name, "audioUrl" : audio_name}
+        new_song = {"title": music_title, "artist": artist, "lyrics": lyrics, "like": False, "isDownloaded": False, "imgUri" : img_uri, "audioUri" : audio_uri}
         iid = music_collection.insert_one(new_song).inserted_id
         print(iid)
 

--- a/backoffice-app/requirements.txt
+++ b/backoffice-app/requirements.txt
@@ -3,3 +3,4 @@ pytz
 requests
 streamlit
 streamlit-autorefresh
+google-cloud-storage


### PR DESCRIPTION
## 변경 내용
Backoffice에서 등록하려는 정보를 GCP Bucket에 저장하고 반환 받은 Object Uri를 MongoDB에 저장하는 API를 구현하였습니다.

## 코드 예시
```python
if thumbnail_img is not None:
            img_uri = upload_file(bucket, thumbnail_img, f"thumbnail/{thumbnail_img.name}")
        if audio is not None:
            audio_uri = upload_file(bucket, audio, f"music/{audio.name}")

new_song = {"title": music_title, "artist": artist, "lyrics": lyrics, "like": False, "isDownloaded": False, "imgUri" : img_uri, "audioUri" : audio_uri}
```
## PR 체크리스트

- [ ] 관련 이슈가 연결되어 있나요? (하단의 "고급(Advanced)" 섹션에서 이슈를 연결하세요)
- [ ] PR의 설명이 충분히 자세한가요?


## 테스트 계획

없음

## 출시 노트

없음

